### PR TITLE
Small README.md changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ from chromalab.observer import Cone, Observer, GovardovskiiNomogram
 import matplotlib.pyplot as plt
 import numpy as np
 
-GovardovskiiNomogram(wavelengths1,530).with_preceptoral(od=0.35, lens=1, macular=0).plot(name="No macular pigment")
+wavelengths = np.arange(400, 701, 1)  # set any wavelengths you want
+GovardovskiiNomogram(wavelengths,530).with_preceptoral(od=0.35, lens=1, macular=0).plot(name="No macular pigment")
 plt.legend()
 plt.show()
 ```
@@ -95,8 +96,8 @@ standard_trichromat = Observer.trichromat()
 standard_tetrachromat = Observer.tetrachromat()
 
 d65 = Illuminant.get("D65")
-print(trichromat.observe(D65))
-print(tetrachromat.observe(D65))
+print(standard_trichromat.observe(d65))
+print(standard_tetrachromat.observe(d65))
 ```
 
 **Ink mixing:**
@@ -112,7 +113,7 @@ Example usage:
 ```
 from chromalab.spectra import Spectra, Illuminant
 from chromalab.observer import Observer
-from chromalab.inks import InkGamut
+from chromalab.inks import InkGamut, CellNeugebauer
 import numpy as np
 
 cmy = # ... load neugebauer primaries dict. For CMY, keys will be length 3 binary sequences


### PR DESCRIPTION
some changes in the code examples-noticed some variable naming errors

```
from chromalab.observer import Observer
from chromalab.spectra import Illuminant


standard_trichromat = Observer.trichromat()
standard_tetrachromat = Observer.tetrachromat()

d65 = Illuminant.get("D65")
print(trichromat.observe(D65))
print(tetrachromat.observe(D65))
```
to 
```
from chromalab.observer import Observer
from chromalab.spectra import Illuminant


standard_trichromat = Observer.trichromat()
standard_tetrachromat = Observer.tetrachromat()

D65 = Illuminant.get("D65")
print(standard_trichromat.observe(D65))
print(standard_tetrachromat.observe(D65))
```
and
```
from chromalab.spectra import Spectra, Illuminant
from chromalab.observer import Observer
from chromalab.inks import InkGamut
import numpy as np

cmy = # ... load neugebauer primaries dict. For CMY, keys will be length 3 binary sequences

wavelengths1 = np.arange(390, 701, 1)
d65 = Illuminant.get("D65")
trichromat = Observer.trichromat()

cmy_neug = CellNeugebauer(cmy)
cmy_gamut = InkGamut(cmy, illuminant=d65)
point_cloud, percentages = cmy_gamut.get_point_cloud(trichromat)


```
to 
```
from chromalab.spectra import Spectra, Illuminant
from chromalab.observer import Observer
from chromalab.inks import InkGamut, CellNeugebauer
import numpy as np

cmy = # ... load neugebauer primaries dict. For CMY, keys will be length 3 binary sequences

wavelengths1 = np.arange(390, 701, 1)
d65 = Illuminant.get("D65")
trichromat = Observer.trichromat()

cmy_neug = CellNeugebauer(cmy)
cmy_gamut = InkGamut(cmy, illuminant=d65)
point_cloud, percentages = cmy_gamut.get_point_cloud(trichromat)


```